### PR TITLE
Potential fix for code scanning alert no. 1: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/contoso-traders-app-deployment.yml
+++ b/.github/workflows/contoso-traders-app-deployment.yml
@@ -1,5 +1,9 @@
 name: contoso-traders-app-deployment
 
+permissions:
+  contents: read
+  id-token: write
+
 on:
   workflow_dispatch:
 


### PR DESCRIPTION
Potential fix for [https://github.com/github-cloudlabsuser-2076/contoso/security/code-scanning/1](https://github.com/github-cloudlabsuser-2076/contoso/security/code-scanning/1)

To fix the issue, we will add a `permissions` block at the root level of the workflow. This block will define the minimal permissions required for the workflow to function correctly. Based on the operations in the workflow, the following permissions are necessary:
- `contents: read` to allow the workflow to access the repository's contents.
- `id-token: write` to enable OpenID Connect (OIDC) token issuance for Azure login.
- Additional permissions (e.g., `packages: read`, `pull-requests: write`) can be added if required by specific steps, but they are not evident from the provided code.

The `permissions` block will be added at the top of the workflow, just below the `name` field.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
