### PR TITLE
Potential fix for code scanning alert no. 3: Workflow does not contain permissions

### DIFF
--- a/.github/workflows/update-contoso-traders-app.yml
+++ b/.github/workflows/update-contoso-traders-app.yml
@@ -1,4 +1,6 @@
 name: update contoso traders app
+permissions:
+  contents: read
 
 on:
   workflow_dispatch:


### PR DESCRIPTION
Potential fix for [https://github.com/github-cloudlabsuser-2076/contoso/security/code-scanning/3](https://github.com/github-cloudlabsuser-2076/contoso/security/code-scanning/3)

To fix the issue, we will add a `permissions` block at the root level of the workflow file. This block will restrict the permissions of the `GITHUB_TOKEN` to the minimum required for the workflow to function. Based on the workflow's actions, the minimal required permission is likely `contents: read`, as the workflow primarily interacts with Azure resources and does not modify repository contents.

The `permissions` block will be added immediately after the `name` field (line 1) to apply to all jobs in the workflow.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
